### PR TITLE
Updated url demo

### DIFF
--- a/demo/url.html
+++ b/demo/url.html
@@ -79,7 +79,7 @@
             // Default camera auto focus to on if no distance has been defined
             if (url.camera_auto_focus === undefined && !url.camera_distance)
             {
-                url.camera_auto_focus = true;
+                url.camera_auto_focus = 4.5;
             }
 
             console.dir(url);
@@ -198,7 +198,7 @@
                         {
                             if (url.camera_auto_focus)
                             {
-                                camera.focus(this, 3, 50, url.camera_near_plane === undefined);
+                                camera.focus(this, url.camera_auto_focus, 50, url.camera_near_plane === undefined);
                             }
 
                             if (url.camera_poi_x || !url.camera_poi_y || url.camera_poi_z)


### PR DESCRIPTION
- `url.camera_auto_focus` now expects a number. The value entered is the multiplier used when guessing the camera's distance based on the ship's radius. It defaults to 3 if `url.camera_distance` is not set.